### PR TITLE
Config string should be an array affecting fbomb executable

### DIFF
--- a/lib/main/program/class_methods.rb
+++ b/lib/main/program/class_methods.rb
@@ -310,7 +310,7 @@ module Main
                 when Hash
                   config.to_yaml.split(/\n/)
                 when String
-                  Util.unindent(config)
+                  Util.unindent(config).split(/\n/)
                 else
                   []
               end


### PR DESCRIPTION
Installed fbomb and main 4.7.6 blows up with:

```
main-4.7.6/lib/main/program/class_methods.rb:317:in `config': undefined method `first' for #<String:0x00000100f27820> (NoMethodError)
```

Looks like the config string should be split on newlines like the code above it does if config is a Hash.

My patch fixes fbomb for me.
