### PR TITLE
Don't quote $EDITOR

### DIFF
--- a/lib/main/program/class_methods.rb
+++ b/lib/main/program/class_methods.rb
@@ -323,7 +323,7 @@ module Main
               fd.puts lines
             end
             editor = ENV['EDITOR'] || ENV['EDIT'] || 'vi'
-            system("#{ editor.inspect } #{ config_path }")
+            system("#{ editor } #{ config_path }")
             @config = Map.for(YAML.load(IO.read(config_path)))
           end
         end


### PR DESCRIPTION
I and a friend ran into this bug when our `$EDITOR` was set to `vim -v` and `mate -w` respectively. It will try to shell out `"vim -v" ~/.app/config.yml` which raises the error `vim -v: command not found`.

What's the use case where `$EDITOR` would need to be quoted?
