### PR TITLE
Require FileUtils

### DIFF
--- a/lib/main/program/class_methods.rb
+++ b/lib/main/program/class_methods.rb
@@ -304,6 +304,7 @@ module Main
           if test(?s, config_path)
             @config = Map.for(YAML.load(IO.read(config_path)))
           else
+            require 'fileutils' unless defined?(FileUtils)
             config = args.last
             lines =
               case config


### PR DESCRIPTION
FileUtils may not be loaded [when the config directory is being created](https://github.com/ahoward/main/blob/master/lib/main/program/class_methods.rb#L318).

```
$ cat test.rb 
require 'main'
Main { config email: 'arthur@dent.com' }

$ ruby test.rb 
/Users/Larry/.rvm/gems/ruby-1.9.3-p0-falcon@cloudapp-cli-test/gems/main-4.8.1/lib/main/program/class_methods.rb:318:in `config': uninitialized constant Main::Program::ClassMethods::FileUtils (NameError)
    from test.rb:2:in `block in <main>'
    from /Users/Larry/.rvm/gems/ruby-1.9.3-p0-falcon@cloudapp-cli-test/gems/main-4.8.1/lib/main/program/class_methods.rb:65:in `module_eval'
    from /Users/Larry/.rvm/gems/ruby-1.9.3-p0-falcon@cloudapp-cli-test/gems/main-4.8.1/lib/main/program/class_methods.rb:65:in `build'
    from /Users/Larry/.rvm/gems/ruby-1.9.3-p0-falcon@cloudapp-cli-test/gems/main-4.8.1/lib/main/factories.rb:16:in `run'
    from /Users/Larry/.rvm/gems/ruby-1.9.3-p0-falcon@cloudapp-cli-test/gems/main-4.8.1/lib/main/factories.rb:25:in `Main'
    from test.rb:2:in `<main>'
```
