### PR TITLE
Set correct backtrace when raising parameter exception

### DIFF
--- a/lib/main/parameter.rb
+++ b/lib/main/parameter.rb
@@ -390,7 +390,7 @@ module Main
                GetoptLong::MissingArgument, GetoptLong::InvalidOption => e
           c = Parameter.const_get e.class.name.split(/::/).last
           ex = c.new e.message
-          ex.set_backtrace e.message
+          ex.set_backtrace e.backtrace
           ex.extend Softspoken
           raise ex
         end


### PR DESCRIPTION
I guess this is a copy&paste error.  The code tried to set a string as a backtrace.
