### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -46,8 +46,8 @@ DESCRIPTION
       end
     }
 
-  sets up a program which requires one argument, 'bar', and which may accept one
-  command line switch, '--foo' in addition to the single option/mode which is always
+  sets up a program which requires one argument, 'foo', and which may accept one
+  command line switch, '--bar' in addition to the single option/mode which is always
   accepted and handled appropriately: 'help', '--help', '-h'.  for the most
   part main.rb stays out of your command line namespace but insists that your
   application has at least a help mode/option.


### PR DESCRIPTION
Noticed that the first example in the README refers to 'bar' as the argument and 'foo' as the option. I think it's supposed to be the other way around
