### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.erb
+++ b/README.erb
@@ -372,7 +372,7 @@ HISTORY
           end
         }
 
-    - added sanity check at end of paramter contruction
+    - added sanity check at end of paramter construction
 
     - improved auto usage generation when arity is used with arguments
 


### PR DESCRIPTION
@ahoward, I've corrected a typographical error in the documentation of the [main](https://github.com/ahoward/main) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
