### PR TITLE
Remove depreciation warning in Ruby 2.4

### DIFF
--- a/lib/main/util.rb
+++ b/lib/main/util.rb
@@ -44,7 +44,7 @@ module Main
       def columnize buf, opts = {}
         width = Util.getopt 'width', opts, 80
         indent = Util.getopt 'indent', opts
-        indent = Fixnum === indent ? (' ' * indent) : "#{ indent }"
+        indent = indent.is_a?(Integer) ? (' ' * indent) : "#{ indent }"
         column = []
         words = buf.split %r/\s+/o
         row = "#{ indent }"


### PR DESCRIPTION
When using `main` in Ruby 2.4 (via `sekrets`) I'm seeing the following depreciation warning:

```
/usr/local/bundle/gems/main-6.2.2/lib/main/util.rb:47: warning: constant ::Fixnum is deprecated
```

This PR changes that line to work with both older and newer versions of Ruby.