### PR TITLE
Used type Integer instead of Fixnum (avoid warning since ruby 2.4)

### DIFF
--- a/lib/main/util.rb
+++ b/lib/main/util.rb
@@ -44,7 +44,7 @@ module Main
       def columnize buf, opts = {}
         width = Util.getopt 'width', opts, 80
         indent = Util.getopt 'indent', opts
-        indent = Fixnum === indent ? (' ' * indent) : "#{ indent }"
+        indent = Integer === indent ? (' ' * indent) : "#{ indent }"
         column = []
         words = buf.split %r/\s+/o
         row = "#{ indent }"


### PR DESCRIPTION
Avoid a warning that is triggered in util.rb with ruby 2.5:
/usr/lib/ruby/vendor_ruby/main/util.rb:47: warning: constant ::Fixnum is deprecated

In https://github.com/sass/sass/issues/2218 I found a discussion whether they tested the replacement to "Integer" and it worked in all ruby versions back to 1.8.7.

Feel free to test it.