### PR TITLE
Add dependencies on gems that are no longer default in Ruby 3.5.

### DIFF
--- a/main.gemspec
+++ b/main.gemspec
@@ -63,6 +63,11 @@ Gem::Specification::new do |spec|
   
     spec.add_dependency(*["map", "~> 6.6", ">= 6.6.0"])
   
+    # Gems used by `main` that are no longer in the default gems in Ruby 3.5.0.
+    # TODO: What should the version requirements be?
+    spec.add_dependency(*["logger"])
+    spec.add_dependency(*["ostruct"])
+  
 
   spec.extensions.push(*[])
 


### PR DESCRIPTION
Without this, `main` would fail to load those gems in Ruby 3.5. Resolves a warning in Ruby 3.3.5 and 3.4.

---

When using [Braid](https://github.com/cristibalan/braid) with Ruby 3.3.5, I got the warnings:
```
/home/user/braid/braid-1.wt/lib/braid/main.rb:14: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/home/user/braid/main.gitwt/lib/main.rb:80: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
(The first line number refers to a line in Braid that says `require 'main'`.  I don't know why the warning is blamed on that line rather than on the `require 'logger'` line in `main`.)

So I added the explicit dependencies to the gemspec.  Ideally, they would have meaningful minimum versions, but researching what the minimum versions should be looks like a time sink to me.  If `main` declared a minimum Ruby version, then it would be reasonable to just take the gem versions from that Ruby version, but since it doesn't, the risk of allowing a too-old version of `logger` or `ostruct` doesn't seem fundamentally worse to me than the risk of allowing a too-old Ruby.

The warnings are reported only when running under Bundler (edit 2024-11-04; I'll be happy to update the commit message if/when there's interest in merging this PR).  The presence of the warnings for `logger` and `ostruct` in Ruby 3.3.5 is [considered a bug](https://bugs.ruby-lang.org/issues/20737), and those warnings will be removed in Ruby 3.3.6.  But Ruby 3.4 is expected soon enough (2024-12-25) that I think it's reasonable to go ahead and make this change to reduce the annoyance on Ruby 3.3.5 too.

I looked for documentation about these warnings and didn't find any; I only found [the code in Ruby that generates them](https://github.com/ruby/ruby/blob/master/lib/bundled_gems.rb) in case that's helpful.